### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-copilot.yml
+++ b/.github/workflows/validate-copilot.yml
@@ -1,4 +1,6 @@
 name: Validate Copilot Instructions
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Americana-pro/security/code-scanning/1](https://github.com/Fadil369/Americana-pro/security/code-scanning/1)

To mitigate the risk of unnecessary permissions for the GITHUB_TOKEN and comply with the principle of least privilege, you should add an explicit `permissions` block with the least access required. In this workflow, read access to repository contents suffices. The `permissions` block can be set at the top level (applies to all jobs) or at the job level (under `validate:`). The best practice is to add it at the top level—immediately after the `name:` entry—so all jobs inherit the same limitation, and the workflow's intention is clear. You need to add the following right after `name: Validate Copilot Instructions` on line 1:  
```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
