### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/brainsait-integration/fhir/client.py
+++ b/brainsait-integration/fhir/client.py
@@ -353,7 +353,7 @@ class FHIRClient:
 
         response = self._make_request('POST', '/Observation', data=observation_data)
 
-        logger.info(f"Observation created: {response['id']} for patient {patient_id}")
+        logger.info(f"Observation created: {response['id']} for patient [REDACTED]")
         return Observation(**response)
 
     def get_patient_observations(self, patient_id: str) -> List[Observation]:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Americana-pro/security/code-scanning/4](https://github.com/Fadil369/Americana-pro/security/code-scanning/4)

To fix the problem, we should avoid logging sensitive identifiers such as `patient_id` in log entries. Instead, log only non-sensitive information, or if operationally necessary to log a resource reference, redact it or truncate it so the patient cannot be re-identified from logs. The log message on line 356 should remove or mask the actual value of `patient_id`. You can log just the observation ID, a generic success message, or a truncated/redacted patient identifier if absolutely needed.

The code to change is on line 356 in `brainsait-integration/fhir/client.py`:  
Change  
```python
logger.info(f"Observation created: {response['id']} for patient {patient_id}")
```  
to log only non-sensitive information, for example:  
```python
logger.info(f"Observation created: {response['id']} for patient [REDACTED]")
```
Alternatively, if you want to indicate *which* patient in an operational sense but without logging the full ID, you could mask most of the `patient_id`, e.g.:
```python
logger.info(f"Observation created: {response['id']} for patient {patient_id[:4]}***[REDACTED]")
```
But the safest approach for compliance and to match the recommendation is complete removal or masking.

No new imports or method definitions are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
