### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/brainsait-integration/fhir/client.py
+++ b/brainsait-integration/fhir/client.py
@@ -136,7 +136,7 @@ class FHIRClient:
             return {}
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"FHIR request failed: {method} {url} - {str(e)}")
+            logger.error(f"FHIR request failed: {method} endpoint - {str(e)}")
             raise
 
     def health_check(self) -> bool:


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Americana-pro/security/code-scanning/2](https://github.com/Fadil369/Americana-pro/security/code-scanning/2)

To mitigate the risk, remove patient identifiers from log entries and avoid logging untrusted or sensitive user input directly. Instead, log generic error messages or obfuscate/mask sensitive parameters. In this context, rather than logging the full URL (which embeds the patient ID), log only the HTTP method and endpoint type (e.g., resource class), and a generic error description. For debugging, consider logging only the resource and status code, or log the endpoint and ID only if the ID has been redacted/masked. 

To implement this:
- In brainsait-integration/fhir/client.py, within the `_make_request` function's exception handler (line 139), edit the logger call to exclude the URL (with embedded endpoint and ID) from the log message. Alternatively, log only the endpoint/resource type without specifics, or mask/obfuscate the patient ID.
- You may also add a helper method that redacts IDs from URLs if logging the URL is strictly needed for debugging.

No new imports are needed as the logging module is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
