### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/brainsait-integration/fhir/client.py
+++ b/brainsait-integration/fhir/client.py
@@ -378,7 +378,7 @@ class FHIRClient:
             for entry in response['entry']:
                 observations.append(Observation(**entry['resource']))
 
-        logger.info(f"Found {len(observations)} observations for patient {patient_id}")
+        logger.info(f"Found {len(observations)} observations for patient [REDACTED]")
         return observations
 
     def create_organization(


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/Americana-pro/security/code-scanning/5](https://github.com/Fadil369/Americana-pro/security/code-scanning/5)

To fix this problem, we should remove the logging of the clear text `patient_id`. The log statement should still provide valuable information for debugging/monitoring, but must not include sensitive data such as patient IDs. The best approach is to redact the patient ID in the log message, or to simply state that the observations are for a patient (without specifying which patient), or use a generic identifier such as "[REDACTED]" in place of the actual `patient_id`. 

Specifically, in `brainsait-integration/fhir/client.py`, line 381 should be changed so that it replaces or omits `patient_id` in the log message. For example:
```python
logger.info(f"Found {len(observations)} observations for patient [REDACTED]")
```
or just:
```python
logger.info(f"Found {len(observations)} observations")
```
No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
